### PR TITLE
fix: support esm usage in Node.js for SSR

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "zero-dependency module to fix scrolling when showing modals on mobile devices",
   "main": "index.js",
+  "type": "module",
   "exports": {
     "require": "./dist/index.cjs",
     "import": "./index.js"


### PR DESCRIPTION
I'll be honest, I didn't check that it worked for CJS SSR apps but my understanding is that the "require" key in exports should take care of that. What I can say is that the importing from this project did not work without type module. It works nicely after adding it.